### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
-      dist: precise
+      dist: trusty
     - php: 5.5
-      dist: precise
+      dist: trusty
     - php: 5.6
-      dist: precise
+      dist: trusty
     - php: 7.0
     - php: 7.1
     - php: 7.2
@@ -18,9 +18,10 @@ matrix:
     - php: nightly
     - php: master
   allow_failures:
-    - php: 7.4
     - php: nightly
     - php: master
 before_script:
   - composer self-update
   - travis_retry composer install --prefer-source --no-interaction
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*|5.*"
+        "phpunit/phpunit": "^4.8.36|5.*"
     },
     "license": "MIT and GPL-3.0+",
     "authors": [

--- a/tests/IsCountableTest.php
+++ b/tests/IsCountableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class Ayesh_IsCountable_IsCountableTest extends TestCase {
   public function testIsCountableDeclared() {


### PR DESCRIPTION
# Changed log
- Defining different dist for different PHP version tests on Travis CI build.
- Using the `^4.8.36` version to be compatible with PHPUnit versions easily.
- 