### PR TITLE
Add PHP 8.1 test on GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36|5.*"
+        "phpunit/phpunit": "^4.8.36|5.*|9.*"
     },
     "license": "MIT and GPL-3.0+",
     "authors": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"


### PR DESCRIPTION
# Changed log

- Adding the `php-8.1` test on GitHub workflows.
- Adding the PHPUnit `9.*` to be compatible with `php8.x` versions.
- Removing the `forceCoversAnnotation` attribute setting to ignore `@covers` annotation checking forcedably.